### PR TITLE
Assign vehicles to drives. #311

### DIFF
--- a/app/controllers/api/v1/drives_controller.rb
+++ b/app/controllers/api/v1/drives_controller.rb
@@ -36,6 +36,7 @@ class Api::V1::DrivesController < Api::V1::ApiController
   def update
     activity = create_attributes[:activity]
     @record = Drive.where(driver_id: driver_id).find(params[:id])
+    @record.vehicle_id = @record.tour.try(:vehicle_id)
     authorize @record
     if @record.update_attributes update_attributes.to_h.except(:activity).merge(activity_execution_attributes: activity)
       head :no_content
@@ -47,6 +48,7 @@ class Api::V1::DrivesController < Api::V1::ApiController
   def create
     activity = create_attributes[:activity]
     @record = Drive.new(create_attributes.except(:activity))
+    @record.vehicle_id = @record.tour.try(:vehicle_id)
     @record.activity_execution_attributes = activity || {}
     authorize @record
     if @record.save

--- a/app/controllers/company/drives_controller.rb
+++ b/app/controllers/company/drives_controller.rb
@@ -86,7 +86,11 @@ class Company::DrivesController < ApplicationController
     def fetch_defaults(params)
       if tour
         start_time = tour.last_drive.try(:end) || tour.start_time
-        { start: start_time, end: start_time + 30.minutes, driver: tour.driver, tour_id: params[:tour_id] }
+        { start: start_time,
+          end: start_time + 30.minutes,
+          driver: tour.driver,
+          vehicle: tour.vehicle,
+          tour_id: params[:tour_id] }
       end
     end
 

--- a/app/helpers/drives_helper.rb
+++ b/app/helpers/drives_helper.rb
@@ -38,7 +38,7 @@ module DrivesHelper
   end
 
   def vehicle_select_options
-    Vehicle.where(company_id: current_company.id).kept.all.map { |v| [v.name, v.id] }
+    Vehicle.where(company: current_company).kept.all.map { |v| [v.name, v.id] }
   end
 
   def customer_enabled?

--- a/app/models/drive.rb
+++ b/app/models/drive.rb
@@ -4,11 +4,11 @@
 # represent drives but also any other tasks
 class Drive < ApplicationRecord
   after_initialize :defaults
-  validates :end, date: { after: :start }
 
   # A drive is always done by a driver
   belongs_to :driver
   belongs_to :tour, optional: true
+  belongs_to :vehicle, optional: true
 
   after_save :update_tour
 
@@ -20,6 +20,9 @@ class Drive < ApplicationRecord
   # A Drive may be recorded on a customer but its not necessary
   belongs_to :customer, optional: true
   belongs_to :site, optional: true
+
+  validates :end, date: { after: :start }
+  validate :vehicle_same_as_tour
 
   # Allow to discard instead of destroy drives
   include Discard::Model
@@ -209,6 +212,12 @@ COALESCE(SUM(distance_km), cast('0' as double precision)) as distance")[0]
   end
 
   private
+    def vehicle_same_as_tour
+      if tour&.vehicle && vehicle != tour.vehicle
+        errors.add(:vehicle, :vehicle_not_sames_as_tour)
+      end
+    end
+
     def update_tour
       tour.try(:refresh_times_from_dirves)
     end

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -22,6 +22,7 @@ class Tour < ApplicationRecord
   validate :vehicle_same_company_as_driver
 
   before_validation :set_default_start_time
+  after_update :update_children
 
   # Returns the first drive associated to this
   # tour sorted by starttime
@@ -136,6 +137,15 @@ class Tour < ApplicationRecord
   end
 
   private
+    def update_children
+      changes = {}
+      changes[:vehicle_id] = self.vehicle_id if saved_change_to_attribute?(:vehicle_id)
+      changes[:driver_id] = self.driver_id if saved_change_to_attribute?(:driver_id)
+      unless changes.blank?
+        drives.update_all(changes)
+      end
+    end
+
     def drive_time_not_more_than_tour_time
       if duration_seconds - drives_duration < 1
         errors.add(:base, :total_time_gt_tour_time)

--- a/app/policies/drive_policy.rb
+++ b/app/policies/drive_policy.rb
@@ -36,11 +36,11 @@ class DrivePolicy < ApplicationPolicy
   def permitted_attributes(scope = :default)
     case scope
     when :default
-      [:start, :end, :distance_km, :tour_id, :associated_to_as_json, activity_execution_attributes: [:activity_id, :value]]
+      [:start, :end, :distance_km, :tour_id, :vehicle_id, :associated_to_as_json, activity_execution_attributes: [:activity_id, :value]]
     when :api_create
-      [:driver_id, :start, :end, :company_id, :site_id, :tour_id,  :customer_id, :distance_km, :updated_at, :discarded_at, :created_at, activity: [:activity_id, :value]]
+      [:driver_id, :start, :end, :company_id, :site_id, :tour_id, :vehicle_id, :customer_id, :distance_km, :updated_at, :discarded_at, :created_at, activity: [:activity_id, :value]]
     when :api_update
-      [:driver_id, :start, :end, :site_id, :tour_id, :customer_id, :distance_km, :updated_at, :discarded_at, activity: [:activity_id, :value]]
+      [:driver_id, :start, :end, :site_id, :tour_id, :vehicle_id, :customer_id, :distance_km, :updated_at, :discarded_at, activity: [:activity_id, :value]]
     end
   end
 

--- a/app/views/api/v1/drives/_drive.json.jb
+++ b/app/views/api/v1/drives/_drive.json.jb
@@ -9,6 +9,7 @@ json = {
     customer_id: drive.customer_id,
     site_id: drive.site_id,
     tour_id: drive.tour_id,
+    vehicle_id: drive.vehicle_id,
     created_at: drive.created_at,
     updated_at: drive.updated_at,
     discarded_at: drive.discarded_at

--- a/app/views/drives/_form.html.erb
+++ b/app/views/drives/_form.html.erb
@@ -12,10 +12,22 @@
     <%= render 'drives/attribute_fields', form: form %>
     <% if local_assigns[:can_change_driver] %>
       <div class="form-group col-12">
-        <%= form.label :driver  %>
-        <%= form.select2 :driver_id, drive_driver_select_options %>
+        <% if form.object.tour_id.nil? %>
+          <%= form.label :driver  %>
+          <%= form.select2 :driver_id, drive_driver_select_options %>
+        <% else %>
+          <%= form.hidden_field :driver_id %>
+        <% end %>
       </div>
     <% end %>
+    <div class="form-group col-12">
+      <% if form.object.tour_id.nil? %>
+        <%= form.label :vehicle  %>
+        <%= form.select2 :vehicle_id, vehicle_select_options, { prompt: true } %>
+      <% else %>
+        <%= form.hidden_field :vehicle_id %>
+      <% end %>
+    </div>
     <div class="col-12">
       <%= form.button type: :submit, class: 'btn btn-primary', data: {disable_with: is_processing} do %>
         <%= t('common.ok') %>

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -165,6 +165,7 @@ de-CH:
         salted: "Salzen"
         customer: "Kunde"
         site: "Objekt"
+        vehicle: "Fahrzeug"
         salt_refilled: "Salz füllen"
         task:
           salt: "Salzen"

--- a/db/migrate/20201209074212_add_vehicle_to_drives.rb
+++ b/db/migrate/20201209074212_add_vehicle_to_drives.rb
@@ -1,0 +1,5 @@
+class AddVehicleToDrives < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :drives, :vehicle, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_03_130517) do
+ActiveRecord::Schema.define(version: 2020_12_09_074212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -154,11 +154,13 @@ ActiveRecord::Schema.define(version: 2020_12_03_130517) do
     t.bigint "site_id"
     t.datetime "discarded_at"
     t.uuid "tour_id"
+    t.bigint "vehicle_id"
     t.index ["customer_id"], name: "index_drives_on_customer_id"
     t.index ["discarded_at"], name: "index_drives_on_discarded_at"
     t.index ["site_id"], name: "index_drives_on_site_id"
     t.index ["start", "end"], name: "index_drives_on_start_and_end"
     t.index ["tour_id"], name: "index_drives_on_tour_id"
+    t.index ["vehicle_id"], name: "index_drives_on_vehicle_id"
   end
 
   create_table "hourly_rates", force: :cascade do |t|
@@ -361,6 +363,7 @@ ActiveRecord::Schema.define(version: 2020_12_03_130517) do
   add_foreign_key "drives", "drivers", name: "fk_drives_driver"
   add_foreign_key "drives", "sites"
   add_foreign_key "drives", "tours"
+  add_foreign_key "drives", "vehicles"
   add_foreign_key "hourly_rates", "activities"
   add_foreign_key "hourly_rates", "companies"
   add_foreign_key "hourly_rates", "customers"

--- a/spec/controllers/api/v1/drives_controller_spec.rb
+++ b/spec/controllers/api/v1/drives_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Api::V1::DrivesController, type: :controller do
   render_views
 
   let(:user) { create(:user) }
-  let(:driver) { create(:driver, user: user) }
+  let(:company) { create(:company) }
+  let(:driver) { create(:driver, user: user, company: company) }
   let(:drive1) { create(:drive, driver: driver, activity_execution: create(:activity_execution)) }
 
   before do
@@ -92,7 +93,8 @@ RSpec.describe Api::V1::DrivesController, type: :controller do
   end
 
   describe "post" do
-    let!(:tour) { create(:tour, driver: driver) }
+    let(:vehicle) { create(:vehicle, company: driver.company) }
+    let(:tour) { create(:tour, driver: driver, vehicle: vehicle) }
     let(:minimal_params) { { start: 1.hour.ago, end: 1.minute.ago, created_at: Time.current, tour_id: tour.id } }
 
     before { post :create, params: { driver_id: driver.to_param, format: :json }.merge(minimal_params) }
@@ -105,7 +107,7 @@ RSpec.describe Api::V1::DrivesController, type: :controller do
 
     describe "response body" do
       subject { api_response }
-      it { is_expected.to have_attribute_values(tour_id: tour.id) }
+      it { is_expected.to have_attribute_values(tour_id: tour.id, vehicle_id: vehicle.id) }
     end
   end
 

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     "person#{n}@example.com"
   end
 
+  sequence :vehicle_name do |n|
+    "Fahrzeug #{n}"
+  end
+
   sequence :site_name do |n|
     "Objekt Hannenbach #{n}"
   end

--- a/spec/factories/vehicles.rb
+++ b/spec/factories/vehicles.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :vehicle do
-    name { "Unimoc" }
+    name { generate(:vehicle_name) }
     discarded_at { nil }
     company
   end

--- a/spec/models/drive_spec.rb
+++ b/spec/models/drive_spec.rb
@@ -254,6 +254,62 @@ RSpec.describe Drive, type: :model do
     end
   end
 
+  describe "vehicles" do
+    it { is_expected.to belong_to(:vehicle).optional }
+
+    describe "validate same vehicle as tour" do
+      let(:company) { create(:company) }
+      let(:driver) { create(:driver, company: company) }
+
+      let(:vehicle1) { create(:vehicle, company: company) }
+      let(:vehicle2) { create(:vehicle, company: company) }
+      let(:tour) { create(:tour, vehicle: vehicle1, driver: driver) }
+
+      context "vehicle different than vehicle on tour" do
+        let(:drive) { build(:drive, tour: tour, vehicle: vehicle2, driver: driver) }
+        before { drive.valid? }
+        subject { drive }
+
+        it { is_expected.not_to be_valid }
+        its(:errors) { is_expected.to have_key(:vehicle) }
+      end
+
+      context "vehicle not explicitly set on drive" do
+        let(:drive) { build(:drive, tour: tour, vehicle: nil, driver: driver) }
+        before { drive.valid? }
+        subject { drive }
+
+        it { is_expected.not_to be_valid }
+        its(:errors) { is_expected.to have_key(:vehicle) }
+      end
+
+      context "vehicle not set on drive and tour" do
+        let(:tour) { create(:tour, vehicle: nil, driver: driver) }
+        let(:drive) { build(:drive, tour: tour, vehicle: nil, driver: driver) }
+        before { drive.valid? }
+        subject { drive }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "no tour and no vehicle set" do
+        let(:drive) { build(:drive, tour: nil, vehicle: nil, driver: driver) }
+        before { drive.valid? }
+        subject { drive }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "no tour and any vehicle set" do
+        let(:drive) { build(:drive, tour: nil, vehicle: vehicle2, driver: driver) }
+        before { drive.valid? }
+        subject { drive }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+
   describe "hourly_rates" do
     # We need to disable transactional specs because implicit hourly rates is based on a db view
     # which will not be populated until the transaction is committed.

--- a/spec/models/tour_spec.rb
+++ b/spec/models/tour_spec.rb
@@ -103,6 +103,20 @@ RSpec.describe Tour, type: :model do
     end
   end
 
+  describe "update drives on changes" do
+    let(:company) { create(:company) }
+    subject { create(:tour, driver: create(:driver, company: company)) }
+    let(:drive) { create(:drive, tour: subject) }
+
+    it "changes the vehicle of the drive when updating tour vehicle" do
+      new_vehicle = create(:vehicle, company: company)
+      expect {
+        subject.update_attribute(:vehicle, new_vehicle)
+        drive.reload
+      }.to change(drive, :vehicle).to new_vehicle
+    end
+  end
+
   describe "vehicle assignment" do
     let(:driver) { create(:driver, company: create(:company)) }
     let(:vehicle) { create(:vehicle, company: create(:company)) }


### PR DESCRIPTION
- Allow to set vehicle on a single drive
- Propagate changes to vehicle/driver on a tour to all drives
- Validate same vehicle on tour as on drive
- Closes #311 