### PR TITLE
validate policyterm version date is greater than last acceptance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 before_install:
   - nvm install --lts
   - npm install yarn

--- a/app/models/policy_term.rb
+++ b/app/models/policy_term.rb
@@ -28,7 +28,10 @@ class PolicyTerm < ApplicationRecord
     def version_date_newer
       return if new_record?
       return unless version_date_changed?
-      if last_known_acceptance_date && last_known_acceptance_date >= version_date
+      # we do use seconds comparison here because tests on ci fail because of a
+      # fraction difference (9.5367431640625e-07), although it uses the same values for created_at in term acceptance
+      # as for the version_date.
+      if last_known_acceptance_date && last_known_acceptance_date.to_i >= version_date.to_i
         errors.add(:version_date, :date_after, date: I18n.localize(last_known_acceptance_date))
       end
     end

--- a/app/models/policy_term.rb
+++ b/app/models/policy_term.rb
@@ -12,15 +12,32 @@ class PolicyTerm < ApplicationRecord
   validates :description, presence: true
   validates :name, presence: true
 
+  before_validation :reject_version_date_change_if_less_than_one_minute
+
   audited
+
+  def last_known_acceptance_date
+    term_acceptances.order(created_at: :desc)
+                    .limit(1)
+                    .pluck(:created_at)
+                    .first
+  end
 
   private
 
     def version_date_newer
       return if new_record?
       return unless version_date_changed?
-      if version_date.before?(attribute_was(:version_date))
-        errors.add(:version_date, :date_after, date: I18n.localize(version_date))
+      if last_known_acceptance_date && last_known_acceptance_date >= version_date
+        errors.add(:version_date, :date_after, date: I18n.localize(last_known_acceptance_date))
+      end
+    end
+
+    def reject_version_date_change_if_less_than_one_minute
+      return if new_record?
+      return unless version_date_changed?
+      if (attribute_was(:version_date).to_i - version_date.to_i).abs < 60
+        restore_version_date!
       end
     end
 end

--- a/app/views/term_acceptances/_form.html.erb
+++ b/app/views/term_acceptances/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_for(@user, as: 'user', url: term_acceptances_path, builder: BootstrapFormBuilder, html: { role: 'form' }) do |f| %>
+  <% if @user.errors.any? %>
+    <ul>
+      <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <%= f.hidden_field :id %>
+
+  <% @user.terms_with_updates.each do |t| %>
+    <%= render 'policy_terms/policy_term', policy_term: t %>
+  <% end %>
+  <% @user.unchecked_terms.each do |t| %>
+    <%= render 'policy_terms/policy_term', policy_term: t %>
+  <% end %>
+  <%= f.submit t('common.continue', default: 'Weiter'), class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/term_acceptances/edit.html.erb
+++ b/app/views/term_acceptances/edit.html.erb
@@ -3,24 +3,13 @@
     <h2><%= t 'views.policies_and_terms.require_new_concent' %></h2>
   </div>
   <div class="card-body">
-    <%= form_for(@user, as: 'user', url: term_acceptances_path, builder: BootstrapFormBuilder, html: { role: 'form' }) do |f| %>
-      <% if @user.errors.any? %>
-        <ul>
-          <% @user.errors.full_messages.each do |msg| %>
-            <li><%= msg %></li>
-          <% end %>
-        </ul>
-      <% end %>
-
-      <%= f.hidden_field :id %>
-
-      <% @user.terms_with_updates.each do |t| %>
-        <%= render 'policy_terms/policy_term', policy_term: t %>
-      <% end %>
-      <% @user.unchecked_terms.each do |t| %>
-        <%= render 'policy_terms/policy_term', policy_term: t %>
-      <% end %>
-      <%= f.submit t('common.continue', default: 'Sign up'), class: 'btn btn-primary' %>
+    <% if @user.terms_with_updates.empty? && @user.unchecked_terms.empty? %>
+      <div class="alert alert-info">
+        <%= t('views.policies_and_terms.no_new_terms') %>
+      </div>
+      <%= link_to t('common.back'), root_path, class: "btn btn-primary" %>
+    <% else %>
+      <%= render 'form' %>
     <% end %>
   </div>
 <% end %>

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -479,6 +479,7 @@ de-CH:
         no_data_available: "Keine Daten verfügbar"
     policies_and_terms:
       require_new_concent: "Unsere Bestimmungen haben sich geändert"
+      no_new_terms: "Es gibt zurzeit keine Änderungen die akzeptiert werden müssen."
     tours:
       empty: "Keine Kunden Objekte auf dieser Tour erfasst"
     company_tours:

--- a/spec/models/policy_term_spec.rb
+++ b/spec/models/policy_term_spec.rb
@@ -3,4 +3,52 @@
 require "rails_helper"
 
 RSpec.describe PolicyTerm, type: :model do
+  let(:term) { create(:policy_term, version_date: 1.year.ago) }
+
+  describe "reject version_date if difference is less than 60 seconds" do
+    let(:version_date) { term.version_date }
+    it "will not change version date if change is less than 1 minute" do
+      term.version_date = version_date + 59.seconds
+      expect(term).to be_valid
+      term.save
+      expect(term.version_date).to eq version_date
+    end
+
+    it "will not change version date if change is less than 1 minute in the past" do
+      term.version_date = version_date - 59.seconds
+      expect(term).to be_valid
+      term.save
+      expect(term.version_date).to eq version_date
+    end
+
+    it "Will update the version date if it is set 60 seconds or more later" do
+      term.version_date = version_date + 60.seconds
+      expect(term).to be_valid
+      term.save
+      expect(term.version_date).to eq version_date + 60.seconds
+    end
+  end
+
+  describe "set older version date" do
+    let(:user) { create(:user) }
+    let(:term_acceptance) { create(:term_acceptance, policy_term: term, created_at: 2.months.ago, user: user) }
+    let(:term_acceptance2) { create(:term_acceptance, policy_term: term, created_at: 3.months.ago, user: user) }
+
+    context "without changing version date" do
+      it "is possible to apply changes" do
+        expect(term.update(description: "new text")).to be_truthy
+      end
+    end
+
+    it "must not be possible to set a version date older than the newest acceptance date" do
+      term.version_date = term_acceptance.created_at
+      expect(term).not_to be_valid
+    end
+
+    it "is possible to set a version date that is bigger than the latest term acceptance" do
+      term.version_date = term_acceptance.created_at + 1.second
+      expect(term).to be_valid
+    end
+  end
+
 end

--- a/spec/models/policy_term_spec.rb
+++ b/spec/models/policy_term_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe PolicyTerm, type: :model do
       term.version_date = term_acceptance.created_at
       expect(term).not_to be_valid, lambda { "Term Version date: #{term.version_date},
 Latest acceptance date: #{term.last_known_acceptance_date},
-Diff: #{term.version_date.to_i - term.last_known_acceptance_date.to_i},
+Diff: #{term.version_date.to_f - term.last_known_acceptance_date.to_f},
 New Record: #{term.new_record?},
 Date Changed: #{term.version_date_changed?},
 Expression Result: #{term.last_known_acceptance_date >= term.version_date}" }

--- a/spec/models/policy_term_spec.rb
+++ b/spec/models/policy_term_spec.rb
@@ -42,7 +42,11 @@ RSpec.describe PolicyTerm, type: :model do
 
     it "must not be possible to set a version date older than the newest acceptance date" do
       term.version_date = term_acceptance.created_at
-      expect(term).not_to be_valid, lambda { "Term Version date: #{term.version_date}, Latest acceptance date: #{term.last_known_acceptance_date}" }
+      expect(term).not_to be_valid, lambda { "Term Version date: #{term.version_date},
+Latest acceptance date: #{term.last_known_acceptance_date},
+Diff: #{term.version_date.to_i - term.last_known_acceptance_date.to_i},
+New Record: #{term.new_record?},
+Date Changed: #{term.version_date_changed?}" }
     end
 
     it "is possible to set a version date that is bigger than the latest term acceptance" do

--- a/spec/models/policy_term_spec.rb
+++ b/spec/models/policy_term_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PolicyTerm, type: :model do
 
     it "must not be possible to set a version date older than the newest acceptance date" do
       term.version_date = term_acceptance.created_at
-      expect(term).not_to be_valid
+      expect(term).not_to be_valid, lambda { "Term Version date: #{term.version_date}, Latest acceptance date: #{term.last_known_acceptance_date}" }
     end
 
     it "is possible to set a version date that is bigger than the latest term acceptance" do

--- a/spec/models/policy_term_spec.rb
+++ b/spec/models/policy_term_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe PolicyTerm, type: :model do
 Latest acceptance date: #{term.last_known_acceptance_date},
 Diff: #{term.version_date.to_i - term.last_known_acceptance_date.to_i},
 New Record: #{term.new_record?},
-Date Changed: #{term.version_date_changed?}" }
+Date Changed: #{term.version_date_changed?},
+Expression Result: #{term.last_known_acceptance_date >= term.version_date}" }
     end
 
     it "is possible to set a version date that is bigger than the latest term acceptance" do


### PR DESCRIPTION
This fixes the issue where an existing term can not be changed, because the ui changes the original value of the version_date as it drops the seconds